### PR TITLE
Fix failing compilation with newer versions of MESA

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -3,6 +3,8 @@
 #MESA_DIR = 
 #if you don't set this as an environment variable, set it here
 
+#required for WORK_COMPILE in newer version of MESA
+WORK_SRC_DIR='.'
 #################################################################
 
 # STEP 1: get the standard compiler setup


### PR DESCRIPTION
`WORK_COMPILE` in `$MESA_DIR/utils/makefile_header` now also contains `-I$(WORK_SRC_DIR)`, causing compilation to fail. 